### PR TITLE
Version 0.2.0 - Embedding Extension & Base64 Filter update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,58 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [0.1.0] - UNRELEASED
+## [0.2.0] - 2024-05-28
+
+Embedding Extension & Base64 Filter update
+
+### Added
+
+- The `EmbedExtension` to the Jinja2 environment used that enables using the 
+  `{% embed 'my_file.txt' %}` to embed the requested file "as-is" (so not 
+  parsed as a template or anything like that) into templates wholesale with 
+  these optional arguments:
+  - `indent` (default: 0) to indent each line of the embedded file by a certain
+    number of spaces, e.g. for embedding into YAML files, where indent is 
+    syntactically important
+  - `alviss` (default: `False`) to run the embedded file though the Alviss 
+    "render_loader" before embedding the results
+  - `env` (default: `False`) to make the Alviss parser render `${__ENV__:...}` 
+    expressions
+  - `fidelius` (default: `False`) to make the Alviss parser render 
+    `${__FID__:...}` expressions
+- The main use case here was considered things like creating Kubernetes File 
+  Config maps where e.g. config file content is embedded wholesale into the 
+  manifest's YAML
+- The `base64` filter to the Jinja2 environment used to quicly encode context 
+  variables as base64 encoded strings
+  - The main use case here was considered things like rendering of Kubernetes 
+    Secret manifests where keys need to be base64 encoded  
+- A bunch of "proper" unittests for the new embedding and filter functions
+
+### Changed
+
+- The `FileTemplate` now uses the Jinja2 environment's `FileSystemLoader`, 
+  pre-seeded with search paths of the current working directory (`os.getcwd()`) 
+  as well as the root directory of the script being executed (`sys.argv[0]`) 
+  plus whatever paths are defined in the `STENCIL_TEMPLATE_PATH` environment 
+  variable, if any (multiple paths seperated by `;`)
+
+
+## [0.1.0] - 2024-05-24
 
 Initial release
 
 ### Added
 
-- Everything!
+- The project in its entirety
+- Template types:
+  - `FileTemplate`
+  - `StringTemplate`
+- Context types:
+  - `DictContext`
+  - `KeyWordArgumentContext`
+  - `AlvissContext`
+- Renderer Types
+  - `StringRenderer`
+  - `StdOutRenderer`
+  - `FileRenderer`

--- a/ccpstencil/__init__.py
+++ b/ccpstencil/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.1.0'
+__version__ = '0.2.0'
 
 __author__ = 'Thordur Matthiasson <thordurm@ccpgames.com>'
 __license__ = 'MIT License'

--- a/ccpstencil/context/_alviss.py
+++ b/ccpstencil/context/_alviss.py
@@ -5,13 +5,14 @@ __all__ = [
 from ccpstencil.structs import *
 from alviss import quickloader
 from ccptools.tpu import iters
+from pathlib import Path
 import logging
 log = logging.getLogger(__file__)
 
 
 class AlvissContext(IContext):
-    def __init__(self, file_name: str, **kwargs):
-        self._file_name = file_name
+    def __init__(self, file_name: Union[str, Path], **kwargs):
+        self._file_name = str(file_name)
         self._data = quickloader.autoload(file_name)
         self._update_map: Dict[Tuple[str], Any] = {}
 

--- a/ccpstencil/jinjaext/extensions/__init__.py
+++ b/ccpstencil/jinjaext/extensions/__init__.py
@@ -1,0 +1,1 @@
+from ._embed import *

--- a/ccpstencil/jinjaext/extensions/_embed.py
+++ b/ccpstencil/jinjaext/extensions/_embed.py
@@ -1,0 +1,52 @@
+__all__ = [
+    'EmbedExtension',
+]
+
+import os
+from jinja2 import nodes, TemplateSyntaxError
+from jinja2.ext import Extension
+from ccptools.structs import *
+
+class EmbedExtension(Extension):
+    tags = {'embed'}
+
+    def __init__(self, environment):
+        super().__init__(environment)
+        environment.extend(stencil_renderer=None)
+
+    def parse(self, parser):
+        lineno = next(parser.stream).lineno
+        args = [parser.parse_expression()]
+        source_file = parser.filename
+        kwargs = [nodes.Keyword('source_file', nodes.Const(source_file))]
+        while parser.stream.skip_if('comma'):
+            key = parser.stream.expect('name').value
+            parser.stream.expect('assign')
+            value = parser.parse_expression()
+            kwargs.append(nodes.Keyword(key, value))
+
+        return nodes.CallBlock(self.call_method('_render_embed', args, kwargs), [], [], []).set_lineno(lineno)
+
+    def _render_embed(self, file_path, source_file: Optional[str] = None, indent: int = 0,
+                      alviss: bool = False, env: bool = False,  caller=None, **kwargs):
+        # file_path = os.path.abspath(file_path)
+
+        c = caller()
+
+        caller_source = c.strip()
+
+        # Check if file_path is a variable in the context
+        if hasattr(file_path, '__call__'):
+            file_path = file_path()
+
+        content = self.environment.stencil_renderer.get_embed(file_path, alviss=alviss, env=env)
+
+        # Detect the current line's indentation level
+        if indent:
+            indent_str = ' '*indent
+        else:
+            indent_str = ''
+
+        joiner = f'{indent_str}'
+
+        return f'{indent_str}{joiner.join(content.splitlines(True))}\n'

--- a/ccpstencil/jinjaext/filters/__init__.py
+++ b/ccpstencil/jinjaext/filters/__init__.py
@@ -1,0 +1,1 @@
+from ._base64 import *

--- a/ccpstencil/jinjaext/filters/_base64.py
+++ b/ccpstencil/jinjaext/filters/_base64.py
@@ -1,0 +1,9 @@
+__all__ = [
+    'base64',
+]
+
+import base64 as _base64
+
+
+def base64(value: str) -> str:
+    return _base64.encodebytes(value.encode('utf-8')).decode('utf-8').strip()

--- a/ccpstencil/shortcuts/__init__.py
+++ b/ccpstencil/shortcuts/__init__.py
@@ -1,0 +1,1 @@
+from ._render_stencil import *

--- a/ccpstencil/shortcuts/_render_stencil.py
+++ b/ccpstencil/shortcuts/_render_stencil.py
@@ -1,0 +1,17 @@
+__all__ = [
+    'render_stencil',
+]
+
+
+from ccpstencil.stencils import *
+from ccpstencil.utils import *
+from ccpstencil.structs import *
+
+
+def render_stencil(template: T_PATH, context: Union[Dict, T_PATH]) -> str:
+    renderer = StringRenderer()
+    template = guess_template_by_argument(template, renderer)
+    context = guess_context_by_argument(context)
+    renderer.template = template
+    renderer.context = context
+    return renderer.render()

--- a/ccpstencil/stencils.py
+++ b/ccpstencil/stencils.py
@@ -1,3 +1,6 @@
 from .context import *
 from .template import *
 from .renderer import *
+from .shortcuts import *
+
+

--- a/ccpstencil/structs/__init__.py
+++ b/ccpstencil/structs/__init__.py
@@ -1,3 +1,4 @@
 from ._base import *
+from ._aliases import *
 from .interfaces import *
 from ._errors import *

--- a/ccpstencil/structs/_aliases.py
+++ b/ccpstencil/structs/_aliases.py
@@ -1,0 +1,7 @@
+__all__ = [
+    'T_PATH',
+]
+from typing import Union
+from pathlib import Path
+
+T_PATH = Union[str, Path]

--- a/ccpstencil/structs/_errors.py
+++ b/ccpstencil/structs/_errors.py
@@ -11,6 +11,7 @@ __all__ = [
     'InvalidContextTypeForRendererError',
     'InvalidTemplateTypeForRendererError',
     'OutputFileExistsError',
+    'EmbedFileNotFound',
 ]
 
 
@@ -47,4 +48,8 @@ class InvalidTemplateTypeForRendererError(RenderError, TypeError):
 
 
 class OutputFileExistsError(RenderError, FileExistsError):
+    pass
+
+
+class EmbedFileNotFound(RenderError, FileNotFoundError):
     pass

--- a/ccpstencil/structs/interfaces/_renderer.py
+++ b/ccpstencil/structs/interfaces/_renderer.py
@@ -40,3 +40,11 @@ class IRenderer(abc.ABC):
     @abc.abstractmethod
     def jinja_environment(self) -> jinja2.Environment:
         pass
+
+    @abc.abstractmethod
+    def is_template_loadable(self, template_name: str) -> bool:
+        pass
+
+    @abc.abstractmethod
+    def get_embed(self, file_path: str, source_file: Optional[str] = None, alviss: bool = False, env: bool = False) -> str:
+        pass

--- a/ccpstencil/utils/__init__.py
+++ b/ccpstencil/utils/__init__.py
@@ -1,0 +1,1 @@
+from ._guessers import *

--- a/ccpstencil/utils/_guessers.py
+++ b/ccpstencil/utils/_guessers.py
@@ -1,0 +1,34 @@
+__all__ = [
+    'guess_template_by_argument',
+    'guess_context_by_argument',
+]
+
+from ccpstencil.context import *
+from ccpstencil.template import *
+from ccpstencil.structs import *
+
+from pathlib import Path
+
+
+def guess_template_by_argument(template: T_PATH, renderer: Optional[IRenderer] = None) -> ITemplate:
+    if isinstance(template, Path):
+        return FileTemplate(file_path=template)
+
+    if len(template.splitlines()) > 1:
+        return StringTemplate(template_string=template)
+
+    if renderer and isinstance(template, str):
+        if renderer.is_template_loadable(template):
+            return FileTemplate(file_path=template)
+    as_path = Path(template)
+    if as_path.exists():
+        return FileTemplate(file_path=template)
+    return StringTemplate(template_string=template)
+
+
+def guess_context_by_argument(context: Union[str, Path, Dict]) -> IContext:
+    if isinstance(context, Path):
+        return AlvissContext(file_name=context)
+    if isinstance(context, Dict):
+        return DictContext(context_map=context)
+    return AlvissContext(file_name=context)

--- a/tests/res/embed/alviss_embed.yaml
+++ b/tests/res/embed/alviss_embed.yaml
@@ -1,0 +1,11 @@
+app:
+  module: foo
+  class_name: ${app.module}.Bar
+config:
+  coolness_enabled: True
+  person:
+    __include__: inc/include_file.yaml
+  something:
+    else: Yubbi!
+  environment:
+    value: ${__ENV__:ENVIRONMENT_VARIABLE_FORTY_TWO}

--- a/tests/res/embed/another_embedded_file.py
+++ b/tests/res/embed/another_embedded_file.py
@@ -1,0 +1,7 @@
+
+def main():
+    print("Hello World!")
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/res/embed/context.yaml
+++ b/tests/res/embed/context.yaml
@@ -1,0 +1,16 @@
+app:
+  slug: foo
+  namespace: bar-test
+  version: 1.2.3-beta.4
+
+  conf:
+    file: file_to_embed.json
+    other_file: another_embedded_file.py
+
+  multi_conf:
+    - file_to_embed.json
+    - another_embedded_file.py
+
+  secrets:
+    this_is_confidential: "Its a secret to EVERYBODY!"
+    DB_PASSWORD: "Really Bad Password!"

--- a/tests/res/embed/expected/alviss.yaml
+++ b/tests/res/embed/expected/alviss.yaml
@@ -1,0 +1,28 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: foo-file-configmap
+  namespace: bar-test
+  labels:
+    version: 1.2.3-beta.4
+    addonmanager.kubernetes.io/mode: Reconcile
+data:
+  alviss_embed.yaml: |-
+    app:
+      class_name: foo.Bar
+      module: foo
+    config:
+      coolness_enabled: true
+      environment:
+        value: ${__ENV__:ENVIRONMENT_VARIABLE_FORTY_TWO}
+      person:
+        color: green
+        job: Alien
+        name: Bob
+      something:
+        else: Yubbi!
+
+some:
+  key:
+    in:
+      the: "end"

--- a/tests/res/embed/expected/alviss_env.yaml
+++ b/tests/res/embed/expected/alviss_env.yaml
@@ -1,0 +1,28 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: foo-file-configmap
+  namespace: bar-test
+  labels:
+    version: 1.2.3-beta.4
+    addonmanager.kubernetes.io/mode: Reconcile
+data:
+  alviss_embed.yaml: |-
+    app:
+      class_name: foo.Bar
+      module: foo
+    config:
+      coolness_enabled: true
+      environment:
+        value: '42'
+      person:
+        color: green
+        job: Alien
+        name: Bob
+      something:
+        else: Yubbi!
+
+some:
+  key:
+    in:
+      the: "end"

--- a/tests/res/embed/expected/direct.yaml
+++ b/tests/res/embed/expected/direct.yaml
@@ -1,0 +1,27 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: foo-file-configmap
+  namespace: bar-test
+  labels:
+    version: 1.2.3-beta.4
+    addonmanager.kubernetes.io/mode: Reconcile
+data:
+  file_to_embed.json: |-
+    {
+        "this": "is",
+        "a": "json file"
+    }
+  another_embedded_file.py: |-
+    
+    def main():
+        print("Hello World!")
+    
+    
+    if __name__ == '__main__':
+        main()
+
+some:
+  key:
+    in:
+      the: "end"

--- a/tests/res/embed/expected/list.yaml
+++ b/tests/res/embed/expected/list.yaml
@@ -1,0 +1,27 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: foo-file-configmap
+  namespace: bar-test
+  labels:
+    version: 1.2.3-beta.4
+    addonmanager.kubernetes.io/mode: Reconcile
+data:
+  file_to_embed.json: |-
+    {
+        "this": "is",
+        "a": "json file"
+    }
+  another_embedded_file.py: |-
+    
+    def main():
+        print("Hello World!")
+    
+    
+    if __name__ == '__main__':
+        main()
+
+some:
+  key:
+    in:
+      the: "end"

--- a/tests/res/embed/file_to_embed.json
+++ b/tests/res/embed/file_to_embed.json
@@ -1,0 +1,4 @@
+{
+    "this": "is",
+    "a": "json file"
+}

--- a/tests/res/embed/inc/include_file.yaml
+++ b/tests/res/embed/inc/include_file.yaml
@@ -1,0 +1,3 @@
+name: Bob
+color: green
+job: Alien

--- a/tests/res/embed/template_alviss.yaml
+++ b/tests/res/embed/template_alviss.yaml
@@ -1,0 +1,15 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{app.slug}}-file-configmap
+  namespace: {{app.namespace}}
+  labels:
+    version: {{app.version}}
+    addonmanager.kubernetes.io/mode: Reconcile
+data:
+  alviss_embed.yaml: |-
+    {% embed 'alviss_embed.yaml', indent=4, alviss=True %}
+some:
+  key:
+    in:
+      the: "end"

--- a/tests/res/embed/template_alviss_env.yaml
+++ b/tests/res/embed/template_alviss_env.yaml
@@ -1,0 +1,15 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{app.slug}}-file-configmap
+  namespace: {{app.namespace}}
+  labels:
+    version: {{app.version}}
+    addonmanager.kubernetes.io/mode: Reconcile
+data:
+  alviss_embed.yaml: |-
+    {% embed 'alviss_embed.yaml', indent=4, alviss=True, env=True %}
+some:
+  key:
+    in:
+      the: "end"

--- a/tests/res/embed/template_direct.yaml
+++ b/tests/res/embed/template_direct.yaml
@@ -1,0 +1,17 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{app.slug}}-file-configmap
+  namespace: {{app.namespace}}
+  labels:
+    version: {{app.version}}
+    addonmanager.kubernetes.io/mode: Reconcile
+data:
+  file_to_embed.json: |-
+    {% embed 'file_to_embed.json', indent=4 %}
+  another_embedded_file.py: |-
+    {% embed 'another_embedded_file.py', indent=4 %}
+some:
+  key:
+    in:
+      the: "end"

--- a/tests/res/embed/template_list.yaml
+++ b/tests/res/embed/template_list.yaml
@@ -1,0 +1,17 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{app.slug}}-file-configmap
+  namespace: {{app.namespace}}
+  labels:
+    version: {{app.version}}
+    addonmanager.kubernetes.io/mode: Reconcile
+data:
+  {% for f in app.multi_conf %}
+  {{f}}: |-
+    {% embed f, indent=4 %}
+  {% endfor %}
+some:
+  key:
+    in:
+      the: "end"

--- a/tests/res/embed/template_variable.yaml
+++ b/tests/res/embed/template_variable.yaml
@@ -1,0 +1,17 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{app.slug}}-file-configmap
+  namespace: {{app.namespace}}
+  labels:
+    version: {{app.version}}
+    addonmanager.kubernetes.io/mode: Reconcile
+data:
+  {{app.conf.file}}: |-
+    {% embed app.conf.file, indent=4 %}
+  {{app.conf.other_file}}: |-
+    {% embed app.conf.other_file, indent=4 %}
+some:
+  key:
+    in:
+      the: "end"

--- a/tests/res/filters/base64.yaml
+++ b/tests/res/filters/base64.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{app.slug}}-secrets
+  namespace: {{app.namespace}}
+  labels:
+    version: {{app.version}}
+type: Opaque
+data:
+  {% for k, v in app.secrets.items() %}
+  {{k}}: "{{v|base64}}"
+  {% endfor %}

--- a/tests/res/filters/context.yaml
+++ b/tests/res/filters/context.yaml
@@ -1,0 +1,16 @@
+app:
+  slug: foo
+  namespace: bar-test
+  version: 1.2.3-beta.4
+
+  conf:
+    file: file_to_embed.json
+    other_file: another_embedded_file.py
+
+  multi_conf:
+    - file_to_embed.json
+    - another_embedded_file.py
+
+  secrets:
+    this_is_confidential: "Its a secret to EVERYBODY!"
+    DB_PASSWORD: "Really Bad Password!"

--- a/tests/res/filters/expected/base64.yaml
+++ b/tests/res/filters/expected/base64.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: foo-secrets
+  namespace: bar-test
+  labels:
+    version: 1.2.3-beta.4
+type: Opaque
+data:
+  this_is_confidential: "SXRzIGEgc2VjcmV0IHRvIEVWRVJZQk9EWSE="
+  DB_PASSWORD: "UmVhbGx5IEJhZCBQYXNzd29yZCE="

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -1,0 +1,58 @@
+import unittest
+
+from ccpstencil.stencils import *
+
+import sys
+import os
+import pathlib
+
+_HERE = pathlib.Path(__file__).parent.resolve()
+
+
+def fp(file_name: str) -> str:
+    return str((_HERE / 'res/embed/' / file_name).absolute())
+
+
+def read_expected(file_name: str) -> str:
+    with open(fp(f'expected/{file_name}'), 'r', newline=None) as fin:
+        return fin.read()
+
+
+class TestEmbed(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        os.environ['STENCIL_TEMPLATE_PATH'] = str(_HERE / 'res/embed/')
+        os.environ['ENVIRONMENT_VARIABLE_FORTY_TWO'] = '42'
+
+    def test_direct_embed(self):
+        # res = render_stencil(fp('template_direct.yaml'), )
+        res = render_stencil('template_direct.yaml', fp('context.yaml'))
+        exp = read_expected('direct.yaml')
+        self.assertEqual(exp, res)
+
+    def test_variable_embed(self):
+        res = render_stencil('template_variable.yaml', fp('context.yaml'))
+        exp = read_expected('direct.yaml')
+        self.assertEqual(exp, res)
+
+    def test_list_embed(self):
+        res = render_stencil('template_list.yaml', fp('context.yaml'))
+        exp = read_expected('list.yaml')
+        self.assertEqual(exp, res)
+
+    def test_alviss_embed(self):
+        res = render_stencil('template_alviss.yaml', fp('context.yaml'))
+        exp = read_expected('alviss.yaml')
+        self.assertEqual(exp, res)
+
+    def test_alviss_embed_with_env(self):
+        res = render_stencil('template_alviss_env.yaml', fp('context.yaml'))
+        exp = read_expected('alviss_env.yaml')
+        self.assertEqual(exp, res)
+
+    @classmethod
+    def tearDownClass(cls):
+        if 'STENCIL_TEMPLATE_PATH' in os.environ:
+            del os.environ['STENCIL_TEMPLATE_PATH']
+        if 'ENVIRONMENT_VARIABLE_FORTY_TWO' in os.environ:
+            del os.environ['ENVIRONMENT_VARIABLE_FORTY_TWO']

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,34 @@
+import unittest
+
+from ccpstencil.stencils import *
+
+import sys
+import os
+import pathlib
+
+_HERE = pathlib.Path(__file__).parent.resolve()
+
+
+def fp(file_name: str) -> str:
+    return str((_HERE / 'res/filters/' / file_name).absolute())
+
+
+def read_expected(file_name: str) -> str:
+    with open(fp(f'expected/{file_name}'), 'r', newline=None) as fin:
+        return fin.read()
+
+
+class TestFilters(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        os.environ['STENCIL_TEMPLATE_PATH'] = str(_HERE / 'res/filters/')
+
+    def test_base64(self):
+        res = render_stencil('base64.yaml', fp('context.yaml'))
+        exp = read_expected('base64.yaml')
+        self.assertEqual(exp, res)
+
+    @classmethod
+    def tearDownClass(cls):
+        if 'STENCIL_TEMPLATE_PATH' in os.environ:
+            del os.environ['STENCIL_TEMPLATE_PATH']


### PR DESCRIPTION
### Added

- The `EmbedExtension` to the Jinja2 environment used that enables using the `{% embed 'my_file.txt' %}` to embed the requested file "as-is" (so not parsed as a template or anything like that) into templates wholesale with these optional arguments:
  - `indent` (default: 0) to indent each line of the embedded file by a certain number of spaces, e.g. for embedding into YAML files, where indent is syntactically important
  - `alviss` (default: `False`) to run the embedded file though the Alviss "render_loader" before embedding the results
  - `env` (default: `False`) to make the Alviss parser render `${__ENV__:...}` expressions
  - `fidelius` (default: `False`) to make the Alviss parser render `${__FID__:...}` expressions
- The main use case here was considered things like creating Kubernetes File Config maps where e.g. config file content is embedded wholesale into the manifest's YAML
- The `base64` filter to the Jinja2 environment used to quicly encode context variables as base64 encoded strings
  - The main use case here was considered things like rendering of Kubernetes Secret manifests where keys need to be base64 encoded
- A bunch of "proper" unittests for the new embedding and filter functions

### Changed

- The `FileTemplate` now uses the Jinja2 environment's `FileSystemLoader`, pre-seeded with search paths of the current working directory (`os.getcwd()`) as well as the root directory of the script being executed (`sys.argv[0]`) plus whatever paths are defined in the `STENCIL_TEMPLATE_PATH` environment variable, if any (multiple paths seperated by `;`)