### PR TITLE
Version 0.5.0 - Alviss version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.5.0] - 2024-05-30
+
+## Changed
+
+- Bumped the version requirement of Alviss to 3.3 to get support for the new 
+  `${__PY__:...}` expressions in order to inject module versions into Alviss 
+  contexts for CI/CD manifests
+
+
 ## [0.4.0] - 2024-05-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ should work and was written before any actual code or functionality.
 - [x] kwargs context (via code)
 - [x] Dict context (via code)
 - [x] Alviss file context (json/yaml + inheritance)
-- [ ] Args context (from commandline)
+- [x] Args context (from commandline)
 
 ## Template
 
 - [x] String template (via code)
 - [x] File template
-- [ ] Args template (from commandline)
+- [x] Args template (from commandline)
 - [ ] Directory template
 
 ## Renderer
@@ -35,11 +35,13 @@ should work and was written before any actual code or functionality.
 
 ## Other features...?
 
-- ENV var rendering (can be done via ${__ENV__:FOO} in Alviss input)?
-- Meta-data header in files for Directory rendering that controls file names and/or if they should be rendered or not
-- Meta-data file for directories in Directory rendering that control the directory name?
-- Proper Jinja2 Environment Template Loader to enable Jinja's include/extend stuff?
-- Custom macros/scripts/filters?
+- [x] ENV var rendering (can be done via ${__ENV__:FOO} in Alviss input)?
+- [ ] Meta-data header in files for Directory rendering that controls file names and/or if they should be rendered or not
+  - [x] Skip-if tag for skipping file rendering
+  - [ ] Some meta-tag that can control the output name of a file via the `FileRenderer`
+- [ ] Meta-data file for directories in Directory rendering that control the directory name?
+- [x] Proper Jinja2 Environment Template Loader to enable Jinja's include/extend stuff?
+- [x] Custom macros/scripts/filters?
 
 ## Use Cases
 

--- a/ccpstencil/__init__.py
+++ b/ccpstencil/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.4.0'
+__version__ = '0.5.0'
 
 __author__ = 'Thordur Matthiasson <thordurm@ccpgames.com>'
 __license__ = 'MIT License'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [  # https://pypi.org/classifiers/
 
 dependencies = [
     "ccptools >=1.1, <2",
-    "alviss >= 3.2, <4",
+    "alviss >= 3.3, <4",
     "jinja2 >= 3.1, <4"
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ccptools >=1.1, <2
-alviss >= 3.2, <4
+alviss >= 3.3, <4
 jinja2 >= 3.1, <4


### PR DESCRIPTION
## Changed

- Bumped the version requirement of Alviss to 3.3 to get support for the new `${__PY__:...}` expressions in order to inject module versions into Alviss contexts for CI/CD manifests