### PR TITLE
Version 0.5.1 - Fix to FileRenderer Loop

### DIFF
--- a/ccpstencil/__init__.py
+++ b/ccpstencil/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.5.0'
+__version__ = '0.5.1'
 
 __author__ = 'Thordur Matthiasson <thordurm@ccpgames.com>'
 __license__ = 'MIT License'

--- a/ccpstencil/cli/ccp_stencil/_runner.py
+++ b/ccpstencil/cli/ccp_stencil/_runner.py
@@ -1,6 +1,8 @@
 __all__ = [
     'StencilRunner',
 ]
+import os
+import sys
 from ccptools.structs import *
 from ccpstencil.stencils import *
 import logging
@@ -20,7 +22,15 @@ class StencilRunner:
         self.output: Optional[str] = None
         self.no_overwrite: bool = False
 
+    def _make_cwd_importable(self):
+        cwd = os.getcwd()
+        if self.verbose:
+            log.debug(f'os.getcwd()={cwd}')
+        if cwd not in sys.path:
+            sys.path.append(cwd)
+
     def run(self):
+        self._make_cwd_importable()
         rnd = self.get_renderer()
         rnd.template = self.get_template()
         rnd.context = self.get_context()

--- a/ccpstencil/renderer/_file.py
+++ b/ccpstencil/renderer/_file.py
@@ -22,7 +22,7 @@ class FileRenderer(StringRenderer):
         return super().render()
 
     def _output_rendered_results(self, rendered_string: str) -> str:
-        results = super().render()
+        results = self._render_as_string()
         if results is None:
             return f'Skipped: {self._output_file.absolute()}'
 


### PR DESCRIPTION
## Fixed

- FileRenderer was hitting an infinite loop
- Added dynamic path extension to include cwd to enable `${__PY__:...}` injecting from project roots