### PR TITLE
Version 0.6.0 - SetFilename Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.6.0] - 2024-05-30
+
+## Added
+
+- A new `{% setfilename %}` tag where you can set the desired filename of the 
+  rendered file dynamically in the tags body with normal template code e.g. 
+  using the template context
+
+## Changed
+
+- The `FileRenderer` can now define a directory as output location which will 
+  result in the rendered file to be the same as the input template file name 
+  (if any) unless set explicitly via the `{% setfilename %}` tag.
+
+
+## [0.5.1] - 2024-05-30
+
+## Fixed
+
+- FileRenderer was hitting an infinite loop
+- Added dynamic path extension to include cwd to enable `${__PY__:...}` 
+  injecting from project roots
+
+
 ## [0.5.0] - 2024-05-30
 
 ## Changed

--- a/_sandbox_string.py
+++ b/_sandbox_string.py
@@ -12,7 +12,7 @@ def main():
 
     # rnd = stencils.StringRenderer(ctx, tpl)
     # rnd = stencils.StdOutRenderer(ctx, tpl)
-    rnd = stencils.FileRenderer('./build/something/_sandbox_output.txt', ctx, tpl, overwrite=True)
+    rnd = stencils.FileRenderer('./build/something/', ctx, tpl, overwrite=True)
     print(rnd.render())
 
 

--- a/_sandbox_template.txt
+++ b/_sandbox_template.txt
@@ -1,1 +1,5 @@
+{% setfilename %}
+{{name}}_file.txt asd kasd
+a dnlkjn .a?!289h$
+{% endsetfilename %}
 My name is {{name}} and I am {{age}} years old and my favorite color is NOT {{color}}

--- a/ccpstencil/__init__.py
+++ b/ccpstencil/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.5.1'
+__version__ = '0.6.0'
 
 __author__ = 'Thordur Matthiasson <thordurm@ccpgames.com>'
 __license__ = 'MIT License'

--- a/ccpstencil/cli/ccp_stencil/main.py
+++ b/ccpstencil/cli/ccp_stencil/main.py
@@ -17,7 +17,8 @@ def main():
 
     parser.add_argument('-a', '--arg', action='append', help='Add additional Context arguments from the command line, e.g. -a foo=bar')
 
-    parser.add_argument('-o', '--output', help='File to write the results to (otherwise its just printed to stdout)',
+    parser.add_argument('-o', '--output', help='Path or file to write the results to (otherwise its just printed to stdout).'
+                                               ' If this is only a path, the name of the rendered file will be the same as the input template.',
                               default='', nargs='?')
     parser.add_argument('--no-overwrite', action="store_true", help='Makes sore existing output files are not overwritten')
 

--- a/ccpstencil/jinjaext/extensions/__init__.py
+++ b/ccpstencil/jinjaext/extensions/__init__.py
@@ -1,2 +1,3 @@
 from ._embed import *
 from ._skip_if import *
+from ._setfilename import *

--- a/ccpstencil/jinjaext/extensions/_embed.py
+++ b/ccpstencil/jinjaext/extensions/_embed.py
@@ -2,10 +2,10 @@ __all__ = [
     'EmbedExtension',
 ]
 
-import os
-from jinja2 import nodes, TemplateSyntaxError
+from jinja2 import nodes
 from jinja2.ext import Extension
-from ccptools.structs import *
+from ccpstencil.structs import *
+
 
 class EmbedExtension(Extension):
     tags = {'embed'}
@@ -13,6 +13,10 @@ class EmbedExtension(Extension):
     def __init__(self, environment):
         super().__init__(environment)
         environment.extend(stencil_renderer=None)
+
+    @property
+    def renderer(self) -> IRenderer:
+        return self.environment.stencil_renderer  # noqa
 
     def parse(self, parser):
         lineno = next(parser.stream).lineno
@@ -29,17 +33,12 @@ class EmbedExtension(Extension):
 
     def _render_embed(self, file_path, source_file: Optional[str] = None, indent: int = 0,
                       alviss: bool = False, env: bool = False,  caller=None, **kwargs):
-        # file_path = os.path.abspath(file_path)
-
-        c = caller()
-
-        caller_source = c.strip()
 
         # Check if file_path is a variable in the context
         if hasattr(file_path, '__call__'):
             file_path = file_path()
 
-        content = self.environment.stencil_renderer.get_embed(file_path, alviss=alviss, env=env)
+        content = self.renderer.get_embed(file_path, alviss=alviss, env=env)
 
         # Detect the current line's indentation level
         if indent:

--- a/ccpstencil/jinjaext/extensions/_setfilename.py
+++ b/ccpstencil/jinjaext/extensions/_setfilename.py
@@ -1,0 +1,28 @@
+__all__ = [
+    'SetFilenameExtension',
+]
+
+from jinja2 import nodes
+from jinja2.ext import Extension
+from ccpstencil.structs import *
+
+
+class SetFilenameExtension(Extension):
+    tags = {'setfilename'}
+
+    def __init__(self, environment):
+        super().__init__(environment)
+        environment.extend(stencil_renderer=None)
+
+    @property
+    def renderer(self) -> IRenderer:
+        return self.environment.stencil_renderer  # noqa
+
+    def parse(self, parser):
+        lineno = next(parser.stream).lineno
+        body = parser.parse_statements(('name:endsetfilename',), drop_needle=True)
+        return nodes.CallBlock(self.call_method('_set_filename', []), [], [], body).set_lineno(lineno)
+
+    def _set_filename(self, caller):
+        self.renderer.output_file_name = caller().strip()
+        return ''

--- a/ccpstencil/renderer/_base.py
+++ b/ccpstencil/renderer/_base.py
@@ -35,6 +35,7 @@ class _BaseRenderer(IRenderer, abc.ABC):
         self._load_search_paths()
         self._env: jinja2.Environment = self._make_environment()
         self._load_filters()
+        self._output_file_name: Optional[str] = None
 
     def _make_environment(self) -> jinja2.Environment:
         env = jinja2.Environment(
@@ -184,3 +185,19 @@ class _BaseRenderer(IRenderer, abc.ABC):
         else:
             with open(abs_file_path, 'r', newline=None) as fin:
                 return fin.read()
+
+    @property
+    def output_file_name(self) -> Optional[str]:
+        if self._output_file_name:
+            return self._output_file_name
+
+        if self._template:
+            from ccpstencil.template import FileTemplate
+            if isinstance(self._template, FileTemplate):
+                return self._template.get_file_path().name
+
+        return None
+
+    @output_file_name.setter
+    def output_file_name(self, value: str):
+        self._output_file_name = value or None

--- a/ccpstencil/renderer/_file.py
+++ b/ccpstencil/renderer/_file.py
@@ -8,13 +8,17 @@ from ._string import *
 
 
 class FileRenderer(StringRenderer):
-    def __init__(self, output_file: Union[str, Path],
+    def __init__(self, output_path: Union[str, Path],
                  context: Optional[IContext] = None, template: Optional[ITemplate] = None,
                  overwrite: bool = True,
                  **kwargs):
-        if isinstance(output_file, str):
-            output_file = Path(output_file)
-        self._output_file: Path = output_file
+        if isinstance(output_path, str):
+            output_path = Path(output_path)
+        self._output_path: Path = output_path
+        if not self._output_path.is_dir():
+            self.output_file_name = self._output_path.name
+            self._output_path = self._output_path.parent
+
         self._overwrite = overwrite
         super().__init__(context, template, **kwargs)
 
@@ -23,15 +27,37 @@ class FileRenderer(StringRenderer):
 
     def _output_rendered_results(self, rendered_string: str) -> str:
         results = self._render_as_string()
+        fout_path = self.output_file()
         if results is None:
-            return f'Skipped: {self._output_file.absolute()}'
+            return f'Skipped: {fout_path.absolute()}'
 
-        if self._output_file.exists() and not self._overwrite:
+        if fout_path.exists() and not self._overwrite:
             raise OutputFileExistsError(f'The target output file already exists and overwriting is'
-                                        f' disabled: {self._output_file.absolute()}')
-        self._output_file.parent.mkdir(parents=True, exist_ok=True)
+                                        f' disabled: {fout_path.absolute()}')
+        fout_path.parent.mkdir(parents=True, exist_ok=True)
 
-        with open(self._output_file, 'w') as fout:
+        with open(fout_path, 'w') as fout:
             fout.write(results)
-        return str(self._output_file.absolute())
+        return str(fout_path.absolute())
 
+    def output_file(self) -> Path:
+        name = self.output_file_name
+        if name is None:
+            raise NoOutputFileNameError('no output file name set or found')
+        return self._output_path / Path(self.output_file_name)
+
+    @property
+    def output_file_name(self) -> Optional[str]:
+        if self._output_file_name:
+            return self._output_file_name
+
+        if self._template:
+            from ccpstencil.template import FileTemplate
+            if isinstance(self._template, FileTemplate):
+                return self._template.get_file_path().name
+
+        return None
+
+    @output_file_name.setter
+    def output_file_name(self, value: str):
+        self._output_file_name = value

--- a/ccpstencil/structs/_errors.py
+++ b/ccpstencil/structs/_errors.py
@@ -11,6 +11,7 @@ __all__ = [
     'InvalidContextTypeForRendererError',
     'InvalidTemplateTypeForRendererError',
     'OutputFileExistsError',
+    'NoOutputFileNameError',
     'EmbedFileNotFound',
 
     'CancelRendering',
@@ -50,6 +51,10 @@ class InvalidTemplateTypeForRendererError(RenderError, TypeError):
 
 
 class OutputFileExistsError(RenderError, FileExistsError):
+    pass
+
+
+class NoOutputFileNameError(RenderError, ValueError):
     pass
 
 

--- a/ccpstencil/structs/interfaces/_renderer.py
+++ b/ccpstencil/structs/interfaces/_renderer.py
@@ -48,3 +48,13 @@ class IRenderer(abc.ABC):
     @abc.abstractmethod
     def get_embed(self, file_path: str, source_file: Optional[str] = None, alviss: bool = False, env: bool = False) -> str:
         pass
+
+    @property
+    @abc.abstractmethod
+    def output_file_name(self) -> str:
+        pass
+
+    @output_file_name.setter
+    @abc.abstractmethod
+    def output_file_name(self, value: str):
+        pass

--- a/ccpstencil/template/_file.py
+++ b/ccpstencil/template/_file.py
@@ -14,15 +14,18 @@ class FileTemplate(_BaseTemplate):
         self._file_path: T_PATH = file_path
 
     def _read_file(self) -> str:
-        if isinstance(self._file_path, str):
-            as_path = Path(self._file_path)
-        else:
-            as_path = self._file_path
+        as_path = self.get_file_path()
+
         if not as_path.exists():
             raise TemplateNotFoundError(f'File {as_path} does not exist')
 
         with open(as_path, 'r') as fin:
             return fin.read()
+
+    def get_file_path(self) -> Path:
+        if isinstance(self._file_path, str):
+            return Path(self._file_path)
+        return self._file_path
 
     def get_jinja_template(self) -> jinja2.Template:
         if isinstance(self._file_path, str):


### PR DESCRIPTION
## [0.6.0] - 2024-05-30

## Added

- A new `{% setfilename %}` tag where you can set the desired filename of the 
  rendered file dynamically in the tags body with normal template code e.g. 
  using the template context

## Changed

- The `FileRenderer` can now define a directory as output location which will 
  result in the rendered file to be the same as the input template file name 
  (if any) unless set explicitly via the `{% setfilename %}` tag.