### PR TITLE
Version 0.6.1 - SetFileName Fix

### DIFF
--- a/_sandbox_template.txt
+++ b/_sandbox_template.txt
@@ -1,5 +1,4 @@
 {% setfilename %}
-{{name}}_file.txt asd kasd
-a dnlkjn .a?!289h$
+{{colors.favorite}}_file.txt
 {% endsetfilename %}
-My name is {{name}} and I am {{age}} years old and my favorite color is NOT {{color}}
+My name is {{name}} and I am {{age}} years old and my favorite color is NOT {{colors.weakness}}

--- a/ccpstencil/__init__.py
+++ b/ccpstencil/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.6.0'
+__version__ = '0.6.1'
 
 __author__ = 'Thordur Matthiasson <thordurm@ccpgames.com>'
 __license__ = 'MIT License'

--- a/ccpstencil/cli/ccp_stencil/_runner.py
+++ b/ccpstencil/cli/ccp_stencil/_runner.py
@@ -34,7 +34,9 @@ class StencilRunner:
         rnd = self.get_renderer()
         rnd.template = self.get_template()
         rnd.context = self.get_context()
-        rnd.render()
+        res = rnd.render()
+        if self.output:
+            print(f'Wrote file: {res}')
 
     def get_template(self) -> ITemplate:
         if self.template:

--- a/ccpstencil/cli/ccp_stencil/main.py
+++ b/ccpstencil/cli/ccp_stencil/main.py
@@ -18,7 +18,7 @@ def main():
     parser.add_argument('-a', '--arg', action='append', help='Add additional Context arguments from the command line, e.g. -a foo=bar')
 
     parser.add_argument('-o', '--output', help='Path or file to write the results to (otherwise its just printed to stdout).'
-                                               ' If this is only a path, the name of the rendered file will be the same as the input template.',
+                                               ' If this is a path (ends with /), the name of the rendered file will be the same as the input template.',
                               default='', nargs='?')
     parser.add_argument('--no-overwrite', action="store_true", help='Makes sore existing output files are not overwritten')
 

--- a/ccpstencil/renderer/_file.py
+++ b/ccpstencil/renderer/_file.py
@@ -5,6 +5,8 @@ __all__ = [
 from ccpstencil.structs import *
 from pathlib import Path
 from ._string import *
+import logging
+log = logging.getLogger(__file__)
 
 
 class FileRenderer(StringRenderer):
@@ -12,15 +14,23 @@ class FileRenderer(StringRenderer):
                  context: Optional[IContext] = None, template: Optional[ITemplate] = None,
                  overwrite: bool = True,
                  **kwargs):
-        if isinstance(output_path, str):
-            output_path = Path(output_path)
-        self._output_path: Path = output_path
-        if not self._output_path.is_dir():
-            self.output_file_name = self._output_path.name
-            self._output_path = self._output_path.parent
-
         self._overwrite = overwrite
         super().__init__(context, template, **kwargs)
+        is_dir = False
+        log.debug(f'{output_path=}')
+        if isinstance(output_path, str):
+            if output_path.endswith('\\') or output_path.endswith('/'):
+                is_dir = True
+            output_path = Path(output_path)
+
+        if not is_dir:
+            self.output_file_name = str(output_path.name)
+            self._output_path = output_path.parent
+        else:
+            self._output_path = output_path
+
+        log.debug(f'{self._output_path=}')
+        log.debug(f'{self.output_file_name=}')
 
     def render(self) -> str:
         return super().render()


### PR DESCRIPTION
## Fixed

- Issue where `FileRenderer` output path got truncated by one directory if the target location didn't exist

## Changed

- The `FileRenderer` output is now evaluated as a directory if it ends with a slash (or backslash), otherwise a file